### PR TITLE
Fix hydration error caused by localized time

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import { GetStaticProps } from 'next';
 import Head from 'next/head';
+import { useEffect, useState } from 'react';
 
 import VoiceTracker from '@/containers/VoiceTracker/VoiceTracker';
 import styles from '@/styles/Home.module.css';
@@ -15,10 +16,17 @@ interface IHome {
 }
 
 export default function Home({ currentVoices, dateBuilt, lastVoices, nextStart, nextEnd }: IHome) {
-  const dateBuiltString = formatShortDateTimeString(new Date(dateBuilt));
-  const nextStartString = formatTimeString(new Date(nextStart));
-  const nextEndString = formatTimeString(new Date(nextEnd));
+  const [dateBuiltString, setDateBuiltString] = useState('');
+  const [nextStartString, setNextStartString] = useState('');
+  const [nextEndString, setNextEndString] = useState('');
+
   const nextFullString = `${nextStartString} to ${nextEndString}`;
+
+  useEffect(() => {
+    setDateBuiltString(formatShortDateTimeString(new Date(dateBuilt)));
+    setNextStartString(formatTimeString(new Date(nextStart)));
+    setNextEndString(formatTimeString(new Date(nextEnd)));
+  }, [dateBuilt, nextStart, nextEnd]);
 
   return (
     <>


### PR DESCRIPTION
The previous time formatting led to hydration errors when the server and client used different time zones.  An easy way to reproduce this locally was to build with `TZ=UTC yarn build`.

Initially rendering with empty strings where these times are used and updating them on the first render resolves the issue.