### PR TITLE
Add data validation and ErrorDialog component

### DIFF
--- a/components/ErrorDialog/ErrorDialog.module.css
+++ b/components/ErrorDialog/ErrorDialog.module.css
@@ -1,0 +1,10 @@
+.dialog {
+    background-color: #fff5;
+    border-radius: 10px;
+    text-align: center;
+}
+
+.dialog::backdrop {
+    background-color: #000d;
+    backdrop-filter: blur(5px);
+}

--- a/components/ErrorDialog/ErrorDialog.tsx
+++ b/components/ErrorDialog/ErrorDialog.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import styles from './ErrorDialog.module.css';
+import useImmediateModal from '@/utils/useImmediateModal';
+
+const ErrorDialog: React.FC<{children?: ReactNode}> = ({children}) => {
+  const modal = useImmediateModal();
+
+  return (
+    <dialog ref={modal} className={styles.dialog}>
+      <h1>OUT OF ORDER 😢</h1>
+      {children}
+    </dialog>
+  );
+};
+
+export default ErrorDialog;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import VoiceTracker from '@/containers/VoiceTracker/VoiceTracker';
 import styles from '@/styles/Home.module.css';
 import { formatShortDateTimeString, formatTimeString } from '@/utils/formatters';
 import { VoicesData } from '@/utils/globalInterfaces';
+import ErrorDialog from '@/components/ErrorDialog/ErrorDialog';
 
 interface IHome {
   currentVoices: VoicesData;
@@ -27,6 +28,9 @@ export default function Home({ currentVoices, dateBuilt, lastVoices, nextStart, 
     setNextStartString(formatTimeString(new Date(nextStart)));
     setNextEndString(formatTimeString(new Date(nextEnd)));
   }, [dateBuilt, nextStart, nextEnd]);
+
+  // If current and last voices match, something is wrong with the API
+  const areVoicesValid = currentVoices.district1 !== lastVoices.district1;
 
   return (
     <>
@@ -87,7 +91,24 @@ export default function Home({ currentVoices, dateBuilt, lastVoices, nextStart, 
           </section>
         </section>
 
-        <VoiceTracker currentVoices={currentVoices} lastVoices={lastVoices} nextFullString={nextFullString} />
+        {areVoicesValid ? (
+          <VoiceTracker currentVoices={currentVoices} lastVoices={lastVoices} nextFullString={nextFullString} />
+        ) : (
+          <ErrorDialog>
+            <p>The voices aren't coming through as clearly as usual... </p>
+            <p>
+              Maybe it's time to buy an&nbsp;
+              <a 
+                href='https://runescape.wiki/w/Elven_clan_cape' 
+                target='_blank'
+                rel='noreferrer'
+              >
+                Elven clan cape
+                </a>
+              .
+            </p>
+          </ErrorDialog>
+        )}
       </main>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -95,9 +95,9 @@ export default function Home({ currentVoices, dateBuilt, lastVoices, nextStart, 
           <VoiceTracker currentVoices={currentVoices} lastVoices={lastVoices} nextFullString={nextFullString} />
         ) : (
           <ErrorDialog>
-            <p>The voices aren't coming through as clearly as usual... </p>
+            <p>The voices aren&apos;t coming through as clearly as usual... </p>
             <p>
-              Maybe it's time to buy an&nbsp;
+              Maybe it&apos;s time to buy an&nbsp;
               <a 
                 href='https://runescape.wiki/w/Elven_clan_cape' 
                 target='_blank'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,

--- a/utils/useImmediateModal.ts
+++ b/utils/useImmediateModal.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+const useImmediateModal = () => {
+  const modal = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (modal.current && !modal.current.open) modal.current.showModal();
+  });
+
+  return modal;
+};
+
+export default useImmediateModal;


### PR DESCRIPTION
The API is currently returning the same 2 voices because the data was coming from a Twitter bot, which isn't operating after recent Twitter API changes.

Instead of hardcoding an explanation into the page, this adds a simple validity check and shows an error dialog if the current and last voices match.  Once the API is functional again, this frontend will also be functional with no modification necessary.